### PR TITLE
[ADH-4612] Jobbrowser remove unused functionality

### DIFF
--- a/apps/jobbrowser/src/jobbrowser/conf.py
+++ b/apps/jobbrowser/src/jobbrowser/conf.py
@@ -84,6 +84,14 @@ ENABLE_SCHEDULED_TASKS = Config(
   default=False
 )
 
+ENABLE_LIVY_BROWSER = Config(
+  key="enable_livy_browser",
+  help=_("Show the `Livy` tasks section."),
+  type=coerce_bool,
+  default=False
+
+)
+
 ENABLE_HISTORY_V2 = Config(
   key="enable_history_v2",
   help=_("Show the version 2 of job/query History which unifies the all into one."),

--- a/apps/jobbrowser/src/jobbrowser/conf.py
+++ b/apps/jobbrowser/src/jobbrowser/conf.py
@@ -77,6 +77,13 @@ ENABLE_HIVE_QUERY_BROWSER = Config(
   default=False
 )
 
+ENABLE_SCHEDULED_TASKS = Config(
+  key="enable_scheduled_tasks",
+  help=_("Show the `Scheduled Tasks` section for the celery-beat tasks. If task_server enabled."),
+  type=coerce_bool,
+  default=False
+)
+
 ENABLE_HISTORY_V2 = Config(
   key="enable_history_v2",
   help=_("Show the version 2 of job/query History which unifies the all into one."),

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -1835,6 +1835,9 @@ submit_to=True
 # Show the `Scheduled Tasks` section for the celery-beat tasks. If task_server enabled.
 ## enable_scheduled_tasks=false
 
+# Show the `Livy` tasks section.
+## enable_livy_browser=false
+
 # Use the proxy API instead of the ORM to access the query_store.
 ## use_proxy=true
 

--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -1832,6 +1832,9 @@ submit_to=True
 # Show the Hive section for listing the query history and providing more troubleshooting information.
 ## enable_hive_query_browser=false
 
+# Show the `Scheduled Tasks` section for the celery-beat tasks. If task_server enabled.
+## enable_scheduled_tasks=false
+
 # Use the proxy API instead of the ORM to access the query_store.
 ## use_proxy=true
 

--- a/desktop/core/src/desktop/js/apps/jobBrowser/knockout/JobBrowserViewModel.js
+++ b/desktop/core/src/desktop/js/apps/jobBrowser/knockout/JobBrowserViewModel.js
@@ -76,6 +76,7 @@ export default class JobBrowserViewModel {
         !this.isMini() && schedulerInterfaceCondition();
 
       const schedulerBeatInterfaceCondition = () =>
+        window.ENABLE_SCHEDULED_TASKS &&
         this.appConfig()?.scheduler?.interpreter_names.indexOf('celery-beat') !== -1;
 
       const livyInterfaceCondition = () =>

--- a/desktop/core/src/desktop/js/apps/jobBrowser/knockout/JobBrowserViewModel.js
+++ b/desktop/core/src/desktop/js/apps/jobBrowser/knockout/JobBrowserViewModel.js
@@ -80,6 +80,7 @@ export default class JobBrowserViewModel {
         this.appConfig()?.scheduler?.interpreter_names.indexOf('celery-beat') !== -1;
 
       const livyInterfaceCondition = () =>
+        window.ENABLE_LIVY_BROWSER &&
         !this.isMini() &&
         this.appConfig()?.editor &&
         (this.appConfig().editor.interpreter_names.indexOf('pyspark') !== -1 ||

--- a/desktop/core/src/desktop/templates/global_js_constants.mako
+++ b/desktop/core/src/desktop/templates/global_js_constants.mako
@@ -30,7 +30,7 @@
   from hadoop.conf import UPLOAD_CHUNK_SIZE
   from indexer.conf import ENABLE_NEW_INDEXER
   from jobbrowser.conf import ENABLE_HISTORY_V2, ENABLE_QUERY_BROWSER, ENABLE_HIVE_QUERY_BROWSER, MAX_JOB_FETCH, \
-      QUERY_STORE, ENABLE_SCHEDULED_TASKS
+      QUERY_STORE, ENABLE_SCHEDULED_TASKS, ENABLE_LIVY_BROWSER
   from filebrowser.conf import SHOW_UPLOAD_BUTTON, REMOTE_STORAGE_HOME, MAX_FILE_SIZE_UPLOAD_LIMIT
   from indexer.conf import ENABLE_NEW_INDEXER
   from libsaml.conf import get_logout_redirect_url, CDP_LOGOUT_URL
@@ -190,6 +190,7 @@
   window.ENABLE_HIVE_QUERY_BROWSER = '${ hasattr(ENABLE_QUERY_BROWSER, 'get') and ENABLE_QUERY_BROWSER.get() }' === 'True';
   window.ENABLE_QUERY_BROWSER = '${ hasattr(ENABLE_QUERY_BROWSER, 'get') and ENABLE_QUERY_BROWSER.get() }' === 'True';
   window.ENABLE_SCHEDULED_TASKS = '${ hasattr(ENABLE_SCHEDULED_TASKS, 'get') and ENABLE_SCHEDULED_TASKS.get() }' === 'True';
+  window.ENABLE_LIVY_BROWSER = '${ hasattr(ENABLE_LIVY_BROWSER, 'get') and ENABLE_LIVY_BROWSER.get() }' === 'True';
   window.ENABLE_QUERY_STORE = '${ hasattr(QUERY_STORE, 'IS_ENABLED') and hasattr(QUERY_STORE.IS_ENABLED, 'get') and QUERY_STORE.IS_ENABLED.get() }' === 'True'
   window.ENABLE_SQL_SYNTAX_CHECK = '${ conf.ENABLE_SQL_SYNTAX_CHECK.get() }' === 'True';
 

--- a/desktop/core/src/desktop/templates/global_js_constants.mako
+++ b/desktop/core/src/desktop/templates/global_js_constants.mako
@@ -30,7 +30,7 @@
   from hadoop.conf import UPLOAD_CHUNK_SIZE
   from indexer.conf import ENABLE_NEW_INDEXER
   from jobbrowser.conf import ENABLE_HISTORY_V2, ENABLE_QUERY_BROWSER, ENABLE_HIVE_QUERY_BROWSER, MAX_JOB_FETCH, \
-      QUERY_STORE
+      QUERY_STORE, ENABLE_SCHEDULED_TASKS
   from filebrowser.conf import SHOW_UPLOAD_BUTTON, REMOTE_STORAGE_HOME, MAX_FILE_SIZE_UPLOAD_LIMIT
   from indexer.conf import ENABLE_NEW_INDEXER
   from libsaml.conf import get_logout_redirect_url, CDP_LOGOUT_URL
@@ -189,6 +189,7 @@
   window.ENABLE_HISTORY_V2 = '${ hasattr(ENABLE_HISTORY_V2, 'get') and ENABLE_HISTORY_V2.get() }' === 'True';
   window.ENABLE_HIVE_QUERY_BROWSER = '${ hasattr(ENABLE_QUERY_BROWSER, 'get') and ENABLE_QUERY_BROWSER.get() }' === 'True';
   window.ENABLE_QUERY_BROWSER = '${ hasattr(ENABLE_QUERY_BROWSER, 'get') and ENABLE_QUERY_BROWSER.get() }' === 'True';
+  window.ENABLE_SCHEDULED_TASKS = '${ hasattr(ENABLE_SCHEDULED_TASKS, 'get') and ENABLE_SCHEDULED_TASKS.get() }' === 'True';
   window.ENABLE_QUERY_STORE = '${ hasattr(QUERY_STORE, 'IS_ENABLED') and hasattr(QUERY_STORE.IS_ENABLED, 'get') and QUERY_STORE.IS_ENABLED.get() }' === 'True'
   window.ENABLE_SQL_SYNTAX_CHECK = '${ conf.ENABLE_SQL_SYNTAX_CHECK.get() }' === 'True';
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added parameter for the `Scheduled Tasks`(Jobbrowser) display condition (`False` by default). Because it is pulled up automatically, despite the unconfigured `task_server`
- Added parameter for the `Livy`(Jobbrowser) display condition(`False` by default). Because it is pulled up automatically, although we do not use the Livy interface for the `sparksql` interpreter.

## How was this patch tested?

Manually

