### PR TITLE
[ADH-4589] Improve user jdbc connection

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/jdbc.py
+++ b/desktop/libs/notebook/src/notebook/connectors/jdbc.py
@@ -62,7 +62,7 @@ class JdbcApi(Api):
     if self.cache_key in API_CACHE:
       self.db = API_CACHE[self.cache_key]
     elif 'password' in self.options:
-      username = self.options.get('user') or user.username
+      username = self.user.username
       impersonation_property = self.options.get('impersonation_property')
       self.db = API_CACHE[self.cache_key] = Jdbc(self.options['driver'], self.options['url'], username, self.options['password'],
         impersonation_property=impersonation_property, impersonation_user=user.username)
@@ -76,7 +76,7 @@ class JdbcApi(Api):
 
     if self.db is None or not self.db.test_connection(throw_exception='password' not in properties):
       if 'password' in properties:
-        user = properties.get('user') or self.options.get('user')
+        user = self.user.username
         props['properties'] = {'user': user}
         self.db = API_CACHE[self.cache_key] = Jdbc(self.options['driver'], self.options['url'], user, properties.pop('password'))
         self.db.test_connection(throw_exception=True)

--- a/desktop/libs/notebook/src/notebook/templates/editor_components.mako
+++ b/desktop/libs/notebook/src/notebook/templates/editor_components.mako
@@ -1998,7 +1998,7 @@ else:
       <div class="span6">
         <div class="input-prepend">
           <span class="add-on muted"><i class="fa fa-user"></i></span>
-          <input name="username" type="text" data-bind="value: $root.authSessionUsername" placeholder="${ _('Username') }"/>
+          <input name="username" type="text" data-bind="value: $root.authSessionUsername" placeholder="${ _('Username') }" readonly/>
         </div>
       </div>
       <div class="span6">


### PR DESCRIPTION
## What changes were proposed in this pull request?

When connecting an interpreter with a jdbc interface, user credentials can be set in the options property, but they will be distributed to any user, which is not safe.
Therefore, using the kyuubi[spark] interpreter with jdbc interface as an example, we do not specify a user, expecting that HUE will pass the username of the current user (and request a password if necessary).

```
[[[kyuubi]]]
name=kyuubi[spark]
options='{"url": "<url string>", "driver": "org.apache.kyuubi.jdbc.KyuubiHiveDriver"}'
interface=jdbc
```
This is what happens, the connection form asks for a user (with the username of the current user pre-specified) and a password. Both fields are editable, which creates a potential information security risk.

1) The username field in the Connection data source[JDBC interface] is now read-only.
2) The jdbc interface uses the authenticated user exclusively.