### PR TITLE
ADH-6719: Add new parameter to the kuyubi jdbc connector

### DIFF
--- a/desktop/libs/notebook/src/notebook/connectors/jdbc.py
+++ b/desktop/libs/notebook/src/notebook/connectors/jdbc.py
@@ -59,7 +59,7 @@ class JdbcApi(Api):
     self.db = None
     self.options = interpreter['options']
 
-    if 'enable_auth_form' in interpreter and not interpreter['enable_auth_form']:
+    if 'enable_auth_form' in self.options and self.options['enable_auth_form'] == 'False':
       self.options['password'] = ''
 
     if self.cache_key in API_CACHE:

--- a/desktop/libs/notebook/src/notebook/connectors/jdbc.py
+++ b/desktop/libs/notebook/src/notebook/connectors/jdbc.py
@@ -59,6 +59,9 @@ class JdbcApi(Api):
     self.db = None
     self.options = interpreter['options']
 
+    if 'enable_auth_form' in interpreter and not interpreter['enable_auth_form']:
+      self.options['password'] = ''
+
     if self.cache_key in API_CACHE:
       self.db = API_CACHE[self.cache_key]
     elif 'password' in self.options:


### PR DESCRIPTION
As a solution to bypass the password input form for Kerberos (password not needed) authentication in Kuyybi, we want to add a new boolean parameter (enable_auth_form) to the Kyuubi interpreter, which will be responsible for displaying the form.