### PR TITLE
[ADH-7956] Integration with Vault (Hashicorp/OpenBao) is implemented for storing sensitive configurations.

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -358,6 +358,59 @@ http_500_debug_mode=false
 ## name=john
 ## email=john@doe.com
 
+# Vault integration (Hashicorp/OpenBao)
+# -------------------
+[[vault]]
+# Vault server URL.
+## url='http://127.0.0.1:8200'
+
+# Authentication type. Supported: token, userpass, ldap, kubernetes, kerberos
+## auth_type=token
+
+# Namespace
+## namespace=
+
+# Vault KV engine mount point
+## mount_point=secret
+
+# Vault KV engine version (1 or 2)
+## kv_engine_version=2
+
+# Default key name for secret value retrieval
+## kv_default_key_secret=value
+
+# Token authentication
+## token=
+# Path to file containing Vault token (token or path can be set)
+##token_path=
+
+# Username/Password authentication (userpass, ldap).
+## username=
+## password=
+# Script to execute that returns password for userpass or LDAP authentication
+## password_script=
+
+# Kubernetes authentication
+# Kubernetes role name for Kubernetes authentication
+## kubernetes_role=
+# Path to Kubernetes service account JWT token
+## kubernetes_jwt_path=/var/run/secrets/kubernetes.io/serviceaccount/token
+
+# SSL settings
+#Either a boolean to indicate whether TLS verification should be performed when sending requests to Vault,
+#or a string pointing at the CA bundle to use for verification. See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification.
+## verify=
+# Certificates for use in requests sent to the Vault instance. This should be a tuple with the
+#certificate and then key.
+## cert=
+
+# Timeout settings
+# Request timeout in seconds for Vault operations
+## timeout=30
+
+# Custom mount point
+## auth_mount_point=
+
 # UI customizations
 # -------------------
 [[custom]]

--- a/desktop/conf/pseudo-distributed.ini.tmpl
+++ b/desktop/conf/pseudo-distributed.ini.tmpl
@@ -368,6 +368,59 @@
      name=Hue
      email=hue@localhost.com
 
+  # Vault integration (Hashicorp/OpenBao)
+  # -------------------
+  [[vault]]
+    # Vault server URL.
+    ## url='http://127.0.0.1:8200'
+
+    # Authentication type. Supported: token, userpass, ldap, kubernetes, kerberos
+    ## auth_type=token
+
+    # Namespace
+    ## namespace=
+
+    # Vault KV engine mount point
+    ## mount_point=secret
+
+    # Vault KV engine version (1 or 2)
+    ## kv_engine_version=2
+
+    # Default key name for secret value retrieval
+    ## kv_default_key_secret=value
+
+    # Token authentication
+    ## token=
+    # Path to file containing Vault token (token or path can be set)
+    ##token_path=
+
+    # Username/Password authentication (userpass, ldap).
+    ## username=
+    ## password=
+    # Script to execute that returns password for userpass or LDAP authentication
+    ## password_script=
+
+    # Kubernetes authentication
+    # Kubernetes role name for Kubernetes authentication
+    ## kubernetes_role=
+    # Path to Kubernetes service account JWT token
+    ## kubernetes_jwt_path=/var/run/secrets/kubernetes.io/serviceaccount/token
+
+    # SSL settings
+    #Either a boolean to indicate whether TLS verification should be performed when sending requests to Vault,
+    #or a string pointing at the CA bundle to use for verification. See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification.
+    ## verify=
+    # Certificates for use in requests sent to the Vault instance. This should be a tuple with the
+    #certificate and then key.
+    ## cert=
+
+    # Timeout settings
+    # Request timeout in seconds for Vault operations
+    ## timeout=30
+
+    # Custom mount point
+    ## auth_mount_point=
+
   # UI customizations
   # -------------------
   [[custom]]

--- a/desktop/core/base_requirements.txt
+++ b/desktop/core/base_requirements.txt
@@ -37,6 +37,7 @@ jdcal==1.0.1
 kazoo==2.8.0
 kerberos==1.3.0
 kubernetes==26.1.0
+hvac==2.3.0
 Mako==1.2.3
 Markdown==3.7
 openpyxl==3.0.9

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -147,27 +147,29 @@ def coerce_csv_export_delimiter(delimiter):
 def coerce_vault_verify(value):
   """
   Coerces Vault TLS verify parameter.
-  Supports boolean strings ('true', 'false', '1', '0', 'yes', 'no')
+  Supports boolean strings ('true', 'false')
   or a path to CA bundle.
+  https://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification
   """
   if isinstance(value, bool):
     return value
-
   if isinstance(value, str):
-    upper = value.upper()
-    if upper in ('FALSE', '0', 'NO', 'OFF', 'NAY', ''):
-      return False
-    if upper in ('TRUE', '1', 'YES', 'ON', 'YEA'):
+    if value.lower() == "true":
       return True
+    elif value.lower() == "false":
+      return False
     return value
 
-  raise Exception('Could not coerce %r to Vault verify value' % (value,))
+  raise TypeError(
+    f"Vault verify must be bool, str (false/true) or str (path to CA bundle), got {type(value).__name__}: {value!r}"
+  )
 
 
 def coerce_vault_cert(value):
   """
   Coerces Vault TLS cert parameter.
   Supports tuple/list, comma-separated string, or single path string.
+  https://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification
   """
   if isinstance(value, (list, tuple)):
     return tuple(value)
@@ -177,7 +179,9 @@ def coerce_vault_cert(value):
       return tuple(part.strip() for part in value.split(','))
     return value
 
-  raise Exception('Could not coerce %r to Vault cert value' % (value,))
+  raise TypeError(
+    f"Vault cert must be str, tuple, or list, got {type(value).__name__}: {value!r}"
+  )
 
 
 def is_https_enabled():
@@ -3076,6 +3080,7 @@ VAULT = ConfigSection(
     # SSL settings
     VERIFY_SSL=Config(
       key='verify',
+      default=False,
       type=coerce_vault_verify,
       help='Either a boolean to indicate whether TLS verification should be performed when sending requests to Vault, '
            'or a string pointing at the CA bundle to use for verification.'

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -144,6 +144,42 @@ def coerce_csv_export_delimiter(delimiter):
   return delimiter
 
 
+def coerce_vault_verify(value):
+  """
+  Coerces Vault TLS verify parameter.
+  Supports boolean strings ('true', 'false', '1', '0', 'yes', 'no')
+  or a path to CA bundle.
+  """
+  if isinstance(value, bool):
+    return value
+
+  if isinstance(value, str):
+    upper = value.upper()
+    if upper in ('FALSE', '0', 'NO', 'OFF', 'NAY', ''):
+      return False
+    if upper in ('TRUE', '1', 'YES', 'ON', 'YEA'):
+      return True
+    return value
+
+  raise Exception('Could not coerce %r to Vault verify value' % (value,))
+
+
+def coerce_vault_cert(value):
+  """
+  Coerces Vault TLS cert parameter.
+  Supports tuple/list, comma-separated string, or single path string.
+  """
+  if isinstance(value, (list, tuple)):
+    return tuple(value)
+
+  if isinstance(value, str):
+    if ',' in value:
+      return tuple(part.strip() for part in value.split(','))
+    return value
+
+  raise Exception('Could not coerce %r to Vault cert value' % (value,))
+
+
 def is_https_enabled():
   """Hue is configured for HTTPS."""
   return bool(SSL_CERTIFICATE.get() and SSL_PRIVATE_KEY.get())
@@ -3040,12 +3076,14 @@ VAULT = ConfigSection(
     # SSL settings
     VERIFY_SSL=Config(
       key='verify',
+      type=coerce_vault_verify,
       help='Either a boolean to indicate whether TLS verification should be performed when sending requests to Vault, '
            'or a string pointing at the CA bundle to use for verification.'
     ),
     CERT=Config(
       key='cert',
       default=None,
+      type=coerce_vault_cert,
       help='Certificates for use in requests sent to the Vault instance. This should be a tuple with the '
            'certificate and then key.'
     ),

--- a/desktop/core/src/desktop/conf.py
+++ b/desktop/core/src/desktop/conf.py
@@ -2945,6 +2945,128 @@ OZONE = UnspecifiedConfigSection(
 )
 
 
+# Vault configuration section
+VAULT = ConfigSection(
+  key='vault',
+  help=_('Configuration options for HashiCorp Vault integration for secrets.'),
+  members=dict(
+
+    # Connection settings
+    URL=Config(
+      key='url',
+      default='http://127.0.0.1:8200',
+      help='Vault server URL',
+    ),
+    AUTH_TYPE=Config(
+      key='auth_type',
+      default='token',
+      type=str,
+      help='Authentication type: token, userpass, ldap, kubernetes'
+    ),
+    NAMESPACE=Config(
+      key='namespace',
+      type=str,
+      help='Namespace vault'
+    ),
+
+    # KV engine settings
+    MOUNT_POINT=Config(
+      key='mount_point',
+      default='secret',
+      help='Vault KV engine mount point'
+    ),
+    KV_ENGINE_VERSION=Config(
+      key='kv_engine_version',
+      default=2,
+      type=int,
+      help='Vault KV engine version (1 or 2)'
+    ),
+    KV_DEFAULT_KEY_SECRET=Config(
+      key='kv_default_key_secret',
+      default='value',
+      type=str,
+      help='Default key name for secret value retrieval'
+    ),
+
+    # Token authentication
+    TOKEN=Config(
+      key='token',
+      default=None,
+      type=str,
+      secret=True,
+      help='Vault authentication token'
+    ),
+    TOKEN_PATH=Config(
+      key='token_path',
+      type=str,
+      default=None,
+      help='Path to file containing Vault token'
+    ),
+
+    # Username/Password authentication (userpass, ldap)
+    USERNAME=Config(
+      key='username',
+      type=str,
+      default=None,
+      help='Username for userpass or LDAP authentication'
+    ),
+    PASSWORD=Config(
+      key='password',
+      type=str,
+      default=None,
+      secret=True,
+      help='Password for userpass or LDAP authentication'
+    ),
+    PASSWORD_SCRIPT=Config(
+      key='password_script',
+      type=str,
+      default=None,
+      secret=True,
+      help='Script to execute that returns password for userpass or LDAP authentication'
+    ),
+
+    # Kubernetes authentication
+    KUBERNETES_ROLE=Config(
+      key='kubernetes_role',
+      default=None,
+      help='Kubernetes role name for Kubernetes authentication'
+    ),
+    KUBERNETES_JWT_PATH=Config(
+      key='kubernetes_jwt_path',
+      default='/var/run/secrets/kubernetes.io/serviceaccount/token',
+      help='Path to Kubernetes service account JWT token'
+    ),
+
+    # SSL settings
+    VERIFY_SSL=Config(
+      key='verify',
+      help='Either a boolean to indicate whether TLS verification should be performed when sending requests to Vault, '
+           'or a string pointing at the CA bundle to use for verification.'
+    ),
+    CERT=Config(
+      key='cert',
+      default=None,
+      help='Certificates for use in requests sent to the Vault instance. This should be a tuple with the '
+           'certificate and then key.'
+    ),
+
+    # Timeout settings
+    TIMEOUT=Config(
+      key='timeout',
+      default=30,
+      type=int,
+      help='Request timeout in seconds for Vault operations'
+    ),
+
+    # Auth mount point
+    AUTH_MOUNT_POINT=Config(
+      key='auth_mount_point',
+      default=None,
+      help='Custom mount point '
+    ),
+  )
+)
+
 def is_ofs_enabled():
   return ('default' in list(OZONE.keys()) and OZONE['default'].get_raw() and OZONE['default'].WEBHDFS_URL.get())
 

--- a/desktop/core/src/desktop/lib/conf.py
+++ b/desktop/core/src/desktop/lib/conf.py
@@ -77,6 +77,7 @@ from django.utils.translation import gettext_lazy as _t
 from six import string_types
 
 from desktop.lib.paths import get_build_dir, get_desktop_root
+from desktop.lib.vault_client import resolve_vault_references
 
 try:
   from collections import OrderedDict
@@ -158,6 +159,18 @@ class BoundConfig(object):
   def get(self):
     """Get the data, or its default value."""
     data, present = self._get_data_and_presence()
+
+    # For secret fields, ensure we resolve vault references even during get()
+    if isinstance(data, str) and data.startswith('vault://'):
+      vault_conf_json = GLOBAL_CONFIG.get_data_dict()["desktop"]["vault"]
+      resolved_data = resolve_vault_references(data, vault_conf_json, self.prefix)
+      LOG.debug("Resolved value for %s", data)
+
+      if resolved_data is not None:
+        return self.config.get_value(resolved_data, present=True, prefix=self.prefix, coerce_type=True)
+      else:
+        LOG.error("Failed to resolve vault reference: %s", data)
+
     return self.config.get_value(data, present=present, prefix=self.prefix, coerce_type=True)
 
   def get_raw(self):
@@ -291,6 +304,17 @@ class Config(object):
     """
     if raw is None:
       return raw
+
+    # Resolve vault references for string values
+    if isinstance(raw, str) and raw.startswith('vault://'):
+        vault_conf = GLOBAL_CONFIG.get_data_dict()["desktop"]["vault"]
+        resolved = resolve_vault_references(raw, vault_conf, _)
+        LOG.debug("Resolved value for: %s", raw)
+        if resolved is not None:
+            raw = resolved
+        else:
+            LOG.error("Failed to resolve vault reference: %s", raw)
+
     return self.type(raw)
 
   def print_help(self, out=sys.stdout, indent=0):

--- a/desktop/core/src/desktop/lib/conf.py
+++ b/desktop/core/src/desktop/lib/conf.py
@@ -77,7 +77,6 @@ from django.utils.translation import gettext_lazy as _t
 from six import string_types
 
 from desktop.lib.paths import get_build_dir, get_desktop_root
-from desktop.lib.vault_client import resolve_vault_references
 
 try:
   from collections import OrderedDict
@@ -307,6 +306,7 @@ class Config(object):
 
     # Resolve vault references for string values
     if isinstance(raw, str) and raw.startswith('vault://'):
+        from desktop.lib.vault_client import resolve_vault_references
         vault_conf = GLOBAL_CONFIG.get_data_dict()["desktop"]["vault"]
         resolved = resolve_vault_references(raw, vault_conf, _)
         LOG.debug("Resolved value for: %s", raw)

--- a/desktop/core/src/desktop/lib/conf.py
+++ b/desktop/core/src/desktop/lib/conf.py
@@ -161,6 +161,7 @@ class BoundConfig(object):
 
     # For secret fields, ensure we resolve vault references even during get()
     if isinstance(data, str) and data.startswith('vault://'):
+      from desktop.lib.vault_client import resolve_vault_references
       vault_conf_json = GLOBAL_CONFIG.get_data_dict()["desktop"]["vault"]
       resolved_data = resolve_vault_references(data, vault_conf_json, self.prefix)
       LOG.debug("Resolved value for %s", data)

--- a/desktop/core/src/desktop/lib/conf.py
+++ b/desktop/core/src/desktop/lib/conf.py
@@ -162,14 +162,14 @@ class BoundConfig(object):
     # For secret fields, ensure we resolve vault references even during get()
     if isinstance(data, str) and data.startswith('vault://'):
       from desktop.lib.vault_client import resolve_vault_references
-      vault_conf_json = GLOBAL_CONFIG.get_data_dict()["desktop"]["vault"]
+      vault_conf_json = GLOBAL_CONFIG.get_data_dict().get("desktop", {}).get("vault", {})
       resolved_data = resolve_vault_references(data, vault_conf_json, self.prefix)
       LOG.debug("Resolved value for %s", data)
 
       if resolved_data is not None:
         return self.config.get_value(resolved_data, present=True, prefix=self.prefix, coerce_type=True)
       else:
-        LOG.error("Failed to resolve vault reference: %s", data)
+        raise ValueError("Failed to resolve vault reference: %s" % data)
 
     return self.config.get_value(data, present=present, prefix=self.prefix, coerce_type=True)
 
@@ -308,13 +308,14 @@ class Config(object):
     # Resolve vault references for string values
     if isinstance(raw, str) and raw.startswith('vault://'):
         from desktop.lib.vault_client import resolve_vault_references
-        vault_conf = GLOBAL_CONFIG.get_data_dict()["desktop"]["vault"]
-        resolved = resolve_vault_references(raw, vault_conf, _)
+        vault_conf = GLOBAL_CONFIG.get_data_dict().get("desktop", {}).get("vault", {})
+        resolved_data = resolve_vault_references(raw, vault_conf, _)
         LOG.debug("Resolved value for: %s", raw)
-        if resolved is not None:
-            raw = resolved
+
+        if resolved_data is not None:
+            raw = resolved_data
         else:
-            LOG.error("Failed to resolve vault reference: %s", raw)
+            raise ValueError("Failed to resolve vault reference: %s" % data)
 
     return self.type(raw)
 

--- a/desktop/core/src/desktop/lib/vault_client.py
+++ b/desktop/core/src/desktop/lib/vault_client.py
@@ -19,6 +19,8 @@
 Vault client for resolving vault:// references in configuration.
 """
 
+from __future__ import annotations
+
 import logging
 import re
 import os
@@ -211,19 +213,20 @@ class VaultClient:
 
     def _get_password_from_script(self) -> Optional[str]:
         """Execute script to get password."""
-        script_path = self.config.password_script
-        if not script_path or not os.path.exists(script_path):
+        script = self.config.password_script
+        if not script:
             return None
 
         try:
             result = subprocess.run(
-                [script_path],
+                script,
+                shell=True,
                 capture_output=True,
                 text=True,
                 timeout=30
             )
             if result.returncode == 0:
-                return result.stdout.strip()
+                return result.stdout.strip('\n')
             else:
                 LOG.error("Password script failed: %s", result.stderr)
                 return None

--- a/desktop/core/src/desktop/lib/vault_client.py
+++ b/desktop/core/src/desktop/lib/vault_client.py
@@ -16,17 +16,27 @@
 # limitations under the License.
 
 """
-
+Vault client for resolving vault:// references in configuration.
 """
 
 import logging
 import re
 import os
+import subprocess
 from typing import Optional, Any
 
-import hvac
-from hvac.exceptions import InvalidPath, Forbidden
-from hvac.api.auth_methods import Kubernetes
+try:
+    import hvac
+    from hvac.exceptions import InvalidPath, Forbidden
+    from hvac.api.auth_methods import Kubernetes
+    HAS_HVAC = True
+except ImportError:
+    HAS_HVAC = False
+    hvac = None
+    InvalidPath = Exception
+    Forbidden = Exception
+    Kubernetes = None
+
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
@@ -53,10 +63,14 @@ class VaultClient:
             config: VaultConfig instance with connection parameters
         """
         self.config = config
-        self._client: hvac.Client = None
+        self._client: Optional[Any] = None
         self._initialized = False
         self._token = None
         self._token_expiry = None
+
+        if not HAS_HVAC:
+            LOG.warning("hvac library is not installed. Vault integration is disabled.")
+            return
 
         self._init_client()
 
@@ -178,10 +192,10 @@ class VaultClient:
         try:
             if mount_point:
                 Kubernetes(client_.adapter).login(
-                    role=self.kubernetes_role, jwt=jwt, mount_point=self.auth_mount_point
+                    role=self.config.kubernetes_role, jwt=jwt, mount_point=self.config.auth_mount_point
                 )
             else:
-                Kubernetes(client_.adapter).login(role=self.kubernetes_role, jwt=jwt)
+                Kubernetes(client_.adapter).login(role=self.config.kubernetes_role, jwt=jwt)
             return client_.is_authenticated()
         except Exception as e:
             LOG.error("Kubernetes authentication failed: %s", e)
@@ -197,7 +211,8 @@ class VaultClient:
 
     def _get_password_from_script(self) -> Optional[str]:
         """Execute script to get password."""
-        if not os.path.exists(self.config.password_script):
+        script_path = self.config.password_script
+        if not script_path or not os.path.exists(script_path):
             return None
 
         try:
@@ -218,14 +233,15 @@ class VaultClient:
 
     def _get_token_from_file(self) -> Optional[str]:
         """Read token from file."""
-        if not os.path.exists(self.config.token_path):
+        token_path = self.config.token_path
+        if not token_path or not os.path.exists(token_path):
             return None
 
         try:
-            with open(self.config.token_path, 'r') as f:
+            with open(token_path, 'r') as f:
                 return f.read().strip()
         except Exception as e:
-            LOG.error("Failed to read token from %s: %s", path, e)
+            LOG.error("Failed to read token from %s: %s", token_path, e)
             return None
 
     def _get_kubernetes_jwt(self) -> Optional[str]:
@@ -391,7 +407,7 @@ def resolve_vault_references(value: str, vault_conf: dict, prefix: str = '') -> 
     Called from conf.py when processing configuration values.
 
     Args:
-        value: String possibly containing vault:// reference
+        value: String possibly containing vault reference
         vault_conf: Vault config map
         prefix: Config prefix for logging
 

--- a/desktop/core/src/desktop/lib/vault_client.py
+++ b/desktop/core/src/desktop/lib/vault_client.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+
+"""
+
+import logging
+import re
+import os
+from typing import Optional, Any
+
+import hvac
+from hvac.exceptions import InvalidPath, Forbidden
+from hvac.api.auth_methods import Kubernetes
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+from desktop.lib.vault_conf import VaultConfig, get_vault_config
+
+global _resolver
+
+LOG = logging.getLogger()
+
+# Pattern for vault references: vault://path/to/secret?key=fieldname
+# or vault://path/to/secret (key=value by default)
+VAULT_REF_PATTERN = re.compile(r'^vault://(?P<path>[^?]+)(\?key=(?P<key>[^&]+))?$')
+
+
+class VaultClient:
+    """Minimal Vault client for retrieving secrets."""
+
+    def __init__(self, config: VaultConfig):
+        """
+        Initialize Vault client with VaultConfig.
+
+        Args:
+            config: VaultConfig instance with connection parameters
+        """
+        self.config = config
+        self._client: hvac.Client = None
+        self._initialized = False
+        self._token = None
+        self._token_expiry = None
+
+        self._init_client()
+
+    def _init_client(self):
+        """Initialize the actual Vault client."""
+        try:
+            # Create base client
+            adapter = HTTPAdapter(
+                max_retries=Retry(
+                    total=3,
+                    backoff_factor=0.1,
+                    status_forcelist=[412, 500, 502, 503],
+                    raise_on_status=False,
+                )
+            )
+            session = Session()
+            session.mount("http://", adapter)
+            session.mount("https://", adapter)
+
+            self._client = hvac.Client(
+                url=self.config.url,
+                verify=self.config.verify,
+                cert=self.config.cert,
+                timeout=self.config.timeout,
+                session=session,
+                namespace=self.config.namespace,
+            )
+
+            # Authenticate based on auth_type
+            auth_methods = {
+                'token': self._authenticate_token,
+                'userpass': self._authenticate_userpass,
+                'ldap': self._authenticate_ldap,
+                'kubernetes': self._authenticate_kubernetes,
+            }
+
+            auth_method = auth_methods.get(self.config.auth_type)
+            if not auth_method:
+                LOG.error("Unsupported authentication type: %s", self.config.auth_type)
+                self._client = None
+                return
+
+            if auth_method(self._client):
+                LOG.info("Vault client authenticated successfully. URL: %s, Auth: %s, Mount: %s, KV Version: %d",
+                         self.config.url, self.config.auth_type, self.config.mount_point, int(self.config.kv_engine_version))
+                self._initialized = True
+            else:
+                LOG.error("Vault client authentication failed for auth type: %s", self.config.auth_type)
+                self._client = None
+
+        except Exception as e:
+            LOG.error("Failed to initialize Vault client: %s", e)
+            self._client = None
+
+    @property
+    def client(self):
+        return self._client
+
+    def _authenticate_token(self, client_: hvac.Client) -> bool:
+        """Authenticate using token."""
+        token = self.config.token or self._get_token_from_file()
+        if not token:
+            LOG.error("No token provided for token authentication in VaultClient")
+            return False
+
+        client_.token = token
+        return client_.is_authenticated()
+
+    def _authenticate_userpass(self, client_: hvac.Client) -> bool:
+        """Authenticate using username/password."""
+        password = self._get_password()
+        if not self.config.username or not password:
+            LOG.error("Username or password missing for userpass authentication")
+            return False
+
+        mount_point = self.config.auth_mount_point or "userpass"
+        try:
+            client_.auth.userpass.login(
+                username=self.config.username,
+                password=password,
+                mount_point=mount_point
+            )
+            return client_.is_authenticated()
+        except Exception as e:
+            LOG.error("Userpass authentication failed: %s", e)
+            return False
+
+    def _authenticate_ldap(self, client_: hvac.Client) -> bool:
+        """Authenticate using LDAP."""
+        password = self._get_password()
+        if not self.config.username or not password:
+            LOG.error("Username or password missing for LDAP authentication")
+            return False
+
+        mount_point = self.config.auth_mount_point or "ldap"
+        try:
+            client_.auth.ldap.login(
+                username=self.config.username,
+                password=password,
+                mount_point=mount_point
+            )
+            return client_.is_authenticated()
+        except Exception as e:
+            LOG.error("LDAP authentication failed: %s", e)
+            return False
+
+    def _authenticate_kubernetes(self, client_: hvac.Client) -> bool:
+        """Authenticate using Kubernetes service account."""
+        if not self.config.kubernetes_role:
+            LOG.error("Kubernetes role is required")
+            return False
+
+        jwt = self._get_kubernetes_jwt()
+        if not jwt:
+            LOG.error("Failed to get Kubernetes JWT token")
+            return False
+
+        mount_point = self.config.auth_mount_point
+        try:
+            if mount_point:
+                Kubernetes(client_.adapter).login(
+                    role=self.kubernetes_role, jwt=jwt, mount_point=self.auth_mount_point
+                )
+            else:
+                Kubernetes(client_.adapter).login(role=self.kubernetes_role, jwt=jwt)
+            return client_.is_authenticated()
+        except Exception as e:
+            LOG.error("Kubernetes authentication failed: %s", e)
+            return False
+
+    def _get_password(self) -> Optional[str]:
+        """Get password from config or script."""
+        if self.config.password:
+            return self.config.password
+        if self.config.password_script:
+            return self._get_password_from_script()
+        return None
+
+    def _get_password_from_script(self) -> Optional[str]:
+        """Execute script to get password."""
+        if not os.path.exists(self.config.password_script):
+            return None
+
+        try:
+            result = subprocess.run(
+                [script_path],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+            else:
+                LOG.error("Password script failed: %s", result.stderr)
+                return None
+        except Exception as e:
+            LOG.error("Failed to execute password script: %s", e)
+            return None
+
+    def _get_token_from_file(self) -> Optional[str]:
+        """Read token from file."""
+        if not os.path.exists(self.config.token_path):
+            return None
+
+        try:
+            with open(self.config.token_path, 'r') as f:
+                return f.read().strip()
+        except Exception as e:
+            LOG.error("Failed to read token from %s: %s", path, e)
+            return None
+
+    def _get_kubernetes_jwt(self) -> Optional[str]:
+        """Get Kubernetes JWT token from file."""
+        if self.config.kubernetes_jwt_path and os.path.exists(self.config.kubernetes_jwt_path):
+            try:
+                with open(self.config.kubernetes_jwt_path, 'r') as f:
+                    return f.read().strip()
+            except Exception as e:
+                LOG.error("Failed to read Kubernetes JWT: %s", e)
+        return None
+
+    @property
+    def is_initialized(self):
+        return self._initialized and self._client is not None
+
+    def get_secret(self, path: str, key: str = None) -> Optional[Any]:
+        """
+        Retrieve a secret from Vault.
+
+        Args:
+            path: Path to secret in Vault (without mount point)
+            key: Optional key to extract from secret dict
+
+        Returns:
+            Secret value or entire secret dict if key is None
+        """
+        if not self.is_initialized:
+            LOG.debug("Vault client not initialized")
+            return None
+
+        # Use default key if not specified
+        if key is None:
+            key = self.config.kv_default_key_secret
+
+        # Clean path
+        path = path.strip('/')
+
+        try:
+            LOG.debug("Reading secret: path=%s, mount_point=%s, kv_version=%d",
+                      path, self.config.mount_point, int(self.config.kv_engine_version))
+
+            if int(self.config.kv_engine_version) == 1:
+                response = self.client.secrets.kv.v1.read_secret(
+                    path=path,
+                    mount_point=self.config.mount_point
+                )
+                secret_data = response['data']
+            else:
+                response = self.client.secrets.kv.v2.read_secret_version(
+                    path=path,
+                    mount_point=self.config.mount_point
+                )
+                secret_data = response['data']['data']
+
+            if key:
+                result = secret_data.get(key)
+                if result is None:
+                    LOG.warning("Key '%s' not found in secret. Available keys: %s",
+                                key, list(secret_data.keys()))
+                return result
+            return secret_data
+
+        except InvalidPath:
+            LOG.warning("Secret not found at path: %s (mount_point=%s)",
+                        path, self.config.mount_point)
+            return None
+        except Forbidden:
+            LOG.error("Permission denied reading secret: %s", path)
+            return None
+        except Exception as e:
+            LOG.error("Error reading secret from Vault: %s", str(e))
+            return None
+
+
+class VaultSecretResolver:
+    """Resolver for vault:// references in configuration."""
+
+    def __init__(self, config: VaultConfig):
+        """
+        Initialize resolver with Vault configuration.
+
+        Args:
+            config: VaultConfig instance.
+        """
+        self._client = None
+        self._cache = {}
+        self._config = config
+
+
+    def _get_client(self) -> Optional[VaultClient]:
+        """Get or create Vault client."""
+        self._client = VaultClient(self._config)
+        return self._client if self._client.is_initialized else None
+
+    def resolve(self, value: str, prefix: str = '') -> Optional[Any]:
+        """
+        Resolve a vault:// reference to actual secret.
+
+        Args:
+            value: String containing vault:// reference
+            prefix: Config prefix for logging
+
+        Returns:
+            Resolved value or original value if not a vault reference
+        """
+        if not isinstance(value, str):
+            LOG.warning("Invalid vault reference: %s", value)
+            return value
+
+        match = VAULT_REF_PATTERN.match(value)
+        if not match:
+            LOG.warning("Invalid vault reference: %s", value)
+            return value
+
+        path = match.group('path')
+        key = match.group('key')
+
+        # Check cache
+        cache_key = f"{path}:{key}"
+        if cache_key in self._cache:
+            LOG.debug("Using cached secret for %s", cache_key)
+            return self._cache[cache_key]
+
+        # Get from Vault
+        client = self._get_client()
+        if not client:
+            LOG.warning("Vault client not available for reference: %s", value)
+            return None
+
+        secret = client.get_secret(path, key)
+
+        if secret is not None:
+            self._cache[cache_key] = secret
+            LOG.info("Resolved vault reference: %s for config %s", value, prefix)
+            return secret
+
+        LOG.warning("Failed to resolve vault reference: %s", value)
+        return None
+
+    def clear_cache(self):
+        """Clear the secret cache."""
+        self._cache.clear()
+        LOG.debug("Vault cache cleared")
+
+
+# Global resolver instance - initialized lazily
+VAULT_RESOLVER = None
+
+
+def _get_resolver(vault_conf: dict) -> VaultSecretResolver:
+    """Get or create global resolver."""
+    global VAULT_RESOLVER
+    if VAULT_RESOLVER is None:
+        conf = get_vault_config(vault_conf)
+        VAULT_RESOLVER = VaultSecretResolver(conf)
+    return VAULT_RESOLVER
+
+
+def resolve_vault_references(value: str, vault_conf: dict, prefix: str = '') -> Optional[Any]:
+    """
+    Public function to resolve vault references.
+    Called from conf.py when processing configuration values.
+
+    Args:
+        value: String possibly containing vault:// reference
+        vault_conf: Vault config map
+        prefix: Config prefix for logging
+
+    Returns:
+        Resolved value or original value if not a vault reference
+    """
+    resolver = _get_resolver(vault_conf)
+    return resolver.resolve(value, prefix)

--- a/desktop/core/src/desktop/lib/vault_conf.py
+++ b/desktop/core/src/desktop/lib/vault_conf.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Union
 from dataclasses import dataclass, field
 
 LOG = logging.getLogger()
@@ -36,8 +36,8 @@ class VaultConfig:
     kubernetes_jwt_path: str = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
     # SSL settings
-    verify: Optional[str] = None
-    cert: Optional[str] = None
+    verify: Optional[Union[bool, str]] = None
+    cert: Optional[Union[str, tuple]] = None
 
     # Timeout settings
     timeout: int = 30
@@ -86,7 +86,7 @@ class VaultConfig:
             if not self.kubernetes_role:
                 raise ValueError("kubernetes_role is required for Kubernetes authentication")
 
-        elif int(self.kv_engine_version) not in [1, 2]:
+        if int(self.kv_engine_version) not in [1, 2]:
             raise ValueError("kv_engine_version must be 1 or 2")
 
     def __repr__(self) -> str:

--- a/desktop/core/src/desktop/lib/vault_conf.py
+++ b/desktop/core/src/desktop/lib/vault_conf.py
@@ -1,0 +1,129 @@
+import logging
+from typing import Optional, Dict, Any
+from dataclasses import dataclass, field
+
+LOG = logging.getLogger()
+
+
+@dataclass
+class VaultConfig:
+    """
+    Configuration class for HashiCorpVault/OpenBao connection.
+    Supports multiple authentication methods.
+    """
+
+    # Connection settings
+    url: str
+    namespace: Optional[str] = None
+    auth_type: str = "token"  # token, userpass, ldap,  kubernetes
+
+    # KV engine settings
+    mount_point: str = "secret"
+    kv_engine_version: int = 2
+    kv_default_key_secret: str = "value"
+
+    # Token authentication
+    token: Optional[str] = None
+    token_path: Optional[str] = None
+
+    # Username/Password authentication (userpass, ldap)
+    username: Optional[str] = None
+    password: Optional[str] = None
+    password_script: Optional[str] = None
+
+    # Kubernetes authentication
+    kubernetes_role: Optional[str] = None
+    kubernetes_jwt_path: str = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    # SSL settings
+    verify: Optional[str] = None
+    cert: Optional[str] = None
+
+    # Timeout settings
+    timeout: int = 30
+
+    # Auth mount point
+    auth_mount_point: Optional[str] = None
+
+    # Additional options
+    _unknown_params: Dict[str, Any] = field(default_factory=dict, repr=False, init=False)
+
+    def __init__(self, **kwargs):
+        dataclass_fields = {f.name for f in self.__dataclass_fields__.values()
+                            if not f.name.startswith('_')}
+
+        known_params = {}
+        unknown_params = {}
+
+        for key, value in kwargs.items():
+            if key in dataclass_fields:
+                known_params[key] = value
+            else:
+                unknown_params[key] = value
+
+        for key, value in known_params.items():
+            object.__setattr__(self, key, value)
+
+        object.__setattr__(self, '_unknown_params', unknown_params)
+        self._validate_config()
+
+    def _validate_config(self):
+        """Validate configuration based on auth type."""
+        if not self.url:
+            raise ValueError("Vault URL is required")
+
+        if self.auth_type == "token":
+            if not self.token and not self.token_path:
+                raise ValueError("Either token or token_path is required for token authentication")
+
+        elif self.auth_type in ["userpass", "ldap"]:
+            if not self.username:
+                raise ValueError("Username is required for %s authentication" % self.auth_type)
+            if not self.password and not self.password_script:
+                raise ValueError("Either password or password_script is required for %s authentication" % self.auth_type)
+
+        elif self.auth_type == "kubernetes":
+            if not self.kubernetes_role:
+                raise ValueError("kubernetes_role is required for Kubernetes authentication")
+
+        elif int(self.kv_engine_version) not in [1, 2]:
+            raise ValueError("kv_engine_version must be 1 or 2")
+
+    def __repr__(self) -> str:
+        """String representation without sensitive data"""
+        return f"VaultConfig(url={self.url}, auth_type={self.auth_type}, mount_point={self.mount_point})"
+
+
+# Global configuration instance
+VAULT_CONFIG: Optional[VaultConfig] = None
+
+
+def init_vault_config(vault_config: dict) -> VaultConfig:
+    """
+    Initialize global Vault configuration.
+
+    Args:
+        vault_config: Vault config map
+
+    Returns:
+        Initialized VaultConfig instance
+    """
+    global VAULT_CONFIG
+    
+    if not VAULT_CONFIG:
+        VAULT_CONFIG = VaultConfig(**vault_config)
+
+    return VAULT_CONFIG
+
+
+def get_vault_config(vault_config: dict) -> VaultConfig:
+    """
+    Get global Vault configuration instance.
+
+    Returns:
+        VaultConfig instance
+    """
+    if VAULT_CONFIG is None:
+        LOG.info("Vault configuration initialized.")
+        init_vault_config(vault_config)
+    return VAULT_CONFIG


### PR DESCRIPTION
## What changes were proposed in this pull request?

The patch integrates HashiCorp Vault and OpenBao with the HUE configuration file processing logic. This allows the service to retrieve passwords, secrets, and other sensitive data directly from the KV v2 Vault secrets mechanism, instead of storing them in cleartext in configuration files.

Secrets are expected to be stored as `vault://<path>`

A configuration block for client configuration has been added. **[desktop] [[vault]]**

Authentication types supported

- token
- userpass
- ldap
- kubernetes

